### PR TITLE
feat: extract ENR 4.1, ENR 4.2, and AD 2.2 pages; restore whole-operation atomicity (#12)

### DIFF
--- a/src/sources/eaip_html.py
+++ b/src/sources/eaip_html.py
@@ -284,12 +284,18 @@ def _extract_all(zip_buffer: "BytesIO", dest_dir: Path) -> tuple[dict[str, Path]
                 "The eAIP archive format may have changed."
             )
 
-        # Only create ad2/ if we actually have files for it
-        ad2_dir = dest_dir / _AD2_SUBDIR if staged_ad2 else None
-        if ad2_dir:
-            ad2_dir.mkdir(parents=True, exist_ok=True)
+        # Only create ad2/ if we actually have files for it.
+        # Track whether we created it so we can remove it on rollback.
+        ad2_dir: Path | None = None
+        ad2_dir_created = False
+        if staged_ad2:
+            ad2_dir = dest_dir / _AD2_SUBDIR
+            if not ad2_dir.exists():
+                ad2_dir.mkdir(parents=True, exist_ok=True)
+                ad2_dir_created = True
 
-        # Commit all files atomically — rollback everything on any failure
+        # Commit all files atomically — rollback everything on any failure,
+        # including the ad2/ directory if we just created it.
         committed: dict[str, Path] = {}
         try:
             for name, tmp_path in staged_enr.items():
@@ -303,6 +309,12 @@ def _extract_all(zip_buffer: "BytesIO", dest_dir: Path) -> tuple[dict[str, Path]
         except Exception:
             for committed_path in committed.values():
                 committed_path.unlink(missing_ok=True)
+            # Remove the ad2/ directory only if we created it this call and it is now empty
+            if ad2_dir_created and ad2_dir is not None and ad2_dir.exists():
+                try:
+                    ad2_dir.rmdir()  # only removes if empty — safe to call unconditionally
+                except OSError:
+                    pass  # non-empty (pre-existing files from a previous cycle) — leave it
             raise
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tests/test_eaip_html.py
+++ b/tests/test_eaip_html.py
@@ -348,6 +348,23 @@ class TestExtractAll:
             assert not (tmp_path / name).exists()
         assert not (tmp_path / "ad2").exists()
 
+    def test_move_failure_during_ad2_removes_created_ad2_dir(self, tmp_path):
+        """If a move failure occurs after ad2/ was freshly created, ad2/ must be removed."""
+        import shutil as _real_shutil
+        buf = _make_required_zip({EGEL_AD2_NAME: b"<html/>"})
+        original_move = _real_shutil.move
+
+        def fail_on_ad2(src, dst):
+            if Path(src).name == EGEL_AD2_NAME:
+                raise OSError("simulated failure")
+            original_move(src, dst)
+
+        with patch("src.sources.eaip_html.shutil.move", side_effect=fail_on_ad2):
+            with pytest.raises(OSError):
+                _extract_all(buf, tmp_path)
+
+        assert not (tmp_path / "ad2").exists()
+
     def test_move_failure_during_ad2_rolls_back_enr_files(self, tmp_path):
         """If an AD 2.2 move fails after ENR files were already committed,
         the ENR files must be rolled back too."""


### PR DESCRIPTION
## Summary

- Expands the eAIP zip extractor to pull EG-ENR-4.1, EG-ENR-4.2, and all EG-AD-2.XXXX-en-GB.html files in addition to ENR 3.2/3.3
- AD 2.2 files land in dest_dir/ad2/; missing AD 2.2 files warn but do not raise
- Replaces the two-pass _extract_targets() + _extract_ad2_pages() approach with a new _extract_all() that stages all files in one shared temp dir and commits atomically -- if any move fails, all already-committed files and the freshly-created ad2/ directory are rolled back

## Ari review findings addressed

- High: whole-operation atomicity -- ENR files were committed before AD 2.2 extraction; a mid-AD2 failure left a partial cycle directory. Fixed via _extract_all().
- Medium: _extract_ad2_pages() pre-created ad2/ before confirming matches. Fixed.
- Medium (round 2): rollback removed committed files but left an empty ad2/ directory. Fixed -- rmdir() called on rollback if we created it this call.

## Tests

- TestExtractAll (6 cases) including cross-pass partial-write failure and ad2/ directory rollback
- All 43 tests pass

Closes #12