### PR TITLE
feat: fetch EI_ENR_4_4_EN.pdf from AirNav Ireland each AIRAC cycle

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,3 +35,9 @@ sources:
       - "EG-ENR-4.1-en-GB.html"
       - "EG-ENR-4.2-en-GB.html"
       - "EG-ENR-4.4-en-GB.html"
+  irish_eaip:
+    # AirNav Ireland IAIP package page. ENR 4.4 PDF link is scraped from here
+    # each cycle — the GUID in the download URL changes when AirNav updates the
+    # document. Override if the page URL moves. [RULE:IRISH-EAIP-ENR44-URL]
+    # Confirmed working 2026-03-31.
+    page_url: "https://www.airnav.ie/air-traffic-management/aeronautical-information-management/aip-package"

--- a/src/cli.py
+++ b/src/cli.py
@@ -18,6 +18,7 @@ fetch
     4. Fetch the SRD Excel zip from NATS and extract the .xlsx file.
     5. Validate and convert the SRD Excel to Routes.csv and Notes.csv.
     6. Fetch the VATSIM UK sector file (.sct) from the uk-controller-pack release.
+    7. Fetch EI_ENR_4_4_EN.pdf from the AirNav Ireland IAIP package page (non-fatal).
 
 After fetching, run the SRD Parser to produce out.json, then use the
 airac-archiver tool to package and stage the files: https://github.com/VFPC/airac-archiver
@@ -37,6 +38,7 @@ from src.airac import AiracCycle, current_cycle, cycle_for_date
 from src.config import ConfigError, load
 from src.processing.excel_to_csv import ExcelValidationError, convert_srd_excel
 from src.sources.eaip_html import EaipFetchError, fetch_eaip_html
+from src.sources.irish_eaip_pdf import fetch_irish_enr44
 from src.sources.nats_srd import SrdFetchError, fetch_srd
 from src.sources.vatsim_sct import SctFetchError, fetch_sct
 from src.workspace.directory_manager import (
@@ -170,7 +172,7 @@ def fetch(cycle: str | None) -> None:
     click.echo(f"\nCycle:     {target}")
     click.echo(f"Directory: {work_dir}\n")
 
-    total = 6
+    total = 7
 
     # Step 1 — working directory
     _step(1, total, "Creating working directory")
@@ -229,6 +231,19 @@ def fetch(cycle: str | None) -> None:
         _ok(sct_path.name)
     except SctFetchError as exc:
         _abort(str(exc))
+
+    # Step 7 — Irish ENR 4.4 PDF (non-fatal: warns and continues if unavailable)
+    _step(7, total, "Fetching Irish eAIP ENR 4.4 PDF (EI_ENR_4_4_EN.pdf)")
+    kwargs_ie: dict = {}
+    if cfg.sources.irish_eaip.page_url:
+        kwargs_ie["page_url"] = cfg.sources.irish_eaip.page_url
+    ie_path = fetch_irish_enr44(work_dir, **kwargs_ie)
+    if ie_path:
+        _ok(ie_path.name)
+        cli_logger.info("EI_ENR_4_4_EN.pdf written to %s", ie_path)
+    else:
+        click.echo(" skipped (unavailable — see log for details)")
+        cli_logger.warning("EI_ENR_4_4_EN.pdf fetch skipped — check log for details")
 
     cli_logger.info("=== All files ready — run complete ===")
 

--- a/src/config.py
+++ b/src/config.py
@@ -38,10 +38,16 @@ class EaipConfig:
 
 
 @dataclass(frozen=True)
+class IrishEaipConfig:
+    page_url: str
+
+
+@dataclass(frozen=True)
 class SourcesConfig:
     nats_srd: NatsSrdConfig
     vatsim_sct: VatsimSctConfig
     eaip: EaipConfig
+    irish_eaip: IrishEaipConfig
 
 
 @dataclass(frozen=True)
@@ -99,12 +105,18 @@ def _parse(raw: dict) -> Config:
         files=tuple(eaip.get("files") or []),
     )
 
+    irish = src.get("irish_eaip") or {}
+    irish_eaip_cfg = IrishEaipConfig(
+        page_url=irish.get("page_url") or "",
+    )
+
     return Config(
         workspace_base=workspace_base,
         sources=SourcesConfig(
             nats_srd=nats_srd,
             vatsim_sct=vatsim_sct,
             eaip=eaip_cfg,
+            irish_eaip=irish_eaip_cfg,
         ),
     )
 

--- a/src/sources/irish_eaip_pdf.py
+++ b/src/sources/irish_eaip_pdf.py
@@ -1,0 +1,183 @@
+"""Download EI_ENR_4_4_EN.pdf from the AirNav Ireland IAIP package page.
+
+The Irish eAIP publishes each section as a GUID-based PDF link:
+
+    https://www.airnav.ie/getattachment/{GUID}/EI_ENR_4_4_EN.pdf
+
+The GUID is not deterministic — it changes whenever AirNav replaces the
+document (typically once per AIRAC cycle, sometimes mid-cycle if an interim
+amendment is issued).  The stable entry point is the IAIP package page:
+
+    # [RULE:IRISH-EAIP-ENR44-URL]
+    https://www.airnav.ie/air-traffic-management/aeronautical-information-management/aip-package
+
+The page is fetched as static HTML (no JS rendering required — the ENR
+links are present in the raw markup).  The GUID is extracted by regex and
+the PDF downloaded directly.
+
+Because the Irish AIP is an external dependency outside our control, all
+errors are non-fatal: a warning is logged and the overall fetch continues.
+The GUID that was downloaded is logged so that re-runs can detect whether
+AirNav has issued a replacement document mid-cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# [RULE:IRISH-EAIP-ENR44-URL]
+_IAIP_PACKAGE_URL = (
+    "https://www.airnav.ie"
+    "/air-traffic-management/aeronautical-information-management/aip-package"
+)
+_BASE_URL = "https://www.airnav.ie"
+
+# Regex to locate the ENR 4.4 PDF link within the page HTML.
+# Matches: getattachment/{GUID}/EI_ENR_4_4_EN.pdf
+# [RULE:IRISH-EAIP-ENR44-URL]
+_ENR44_LINK_RE = re.compile(
+    r"getattachment/([\w\-]+)/EI_ENR_4_4_EN\.pdf"
+)
+
+PDF_FILENAME = "EI_ENR_4_4_EN.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class IrishEaipFetchError(Exception):
+    """Raised when the Irish eAIP ENR 4.4 fetch fails unrecoverably."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _fetch_page(url: str, timeout: int = 30) -> str:
+    """Return the HTML text of *url*."""
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def _find_enr44_url(page_html: str, base_url: str = _BASE_URL) -> tuple[str, str]:
+    """Return (absolute_pdf_url, guid) for EI_ENR_4_4_EN.pdf in *page_html*.
+
+    Raises IrishEaipFetchError if the link is not found.
+    """
+    m = _ENR44_LINK_RE.search(page_html)
+    if not m:
+        raise IrishEaipFetchError(
+            "Could not find EI_ENR_4_4_EN.pdf link on the IAIP package page. "
+            "AirNav may have restructured the page. [RULE:IRISH-EAIP-ENR44-URL]"
+        )
+    guid = m.group(1)
+    url = f"{base_url}/getattachment/{guid}/EI_ENR_4_4_EN.pdf?lang=en-IE"
+    return url, guid
+
+
+def _download_pdf(url: str, dest: Path, timeout: int = 60) -> None:
+    """Download *url* and write bytes atomically to *dest*.
+
+    Uses a sibling temp file so the destination is either fully written
+    or absent — never partially written.
+    """
+    tmp_path = dest.with_suffix(".pdf.tmp")
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            tmp_path.write_bytes(resp.read())
+        shutil.move(str(tmp_path), str(dest))
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def fetch_irish_enr44(
+    dest_dir: Path,
+    *,
+    page_url: str = _IAIP_PACKAGE_URL,
+    page_timeout: int = 30,
+    pdf_timeout: int = 60,
+) -> Path | None:
+    """Download EI_ENR_4_4_EN.pdf into *dest_dir*.
+
+    Returns the Path to the downloaded file on success, or None if the
+    fetch fails (warning is logged; the overall pipeline is not aborted).
+
+    Args:
+        dest_dir:     Directory where EI_ENR_4_4_EN.pdf will be written.
+                      Created if it does not exist.
+        page_url:     URL of the AirNav Ireland IAIP package page.
+                      Override for testing or if AirNav changes the URL.
+        page_timeout: HTTP timeout in seconds for the index page fetch.
+        pdf_timeout:  HTTP timeout in seconds for the PDF download.
+
+    The GUID embedded in the download URL is logged at INFO level so that
+    re-runs within the same cycle can detect whether AirNav has silently
+    replaced the document (e.g. an interim amendment).
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = dest_dir / PDF_FILENAME
+
+    try:
+        logger.info("Fetching Irish IAIP package page: %s", page_url)
+        html = _fetch_page(page_url, timeout=page_timeout)
+    except urllib.error.HTTPError as exc:
+        logger.warning(
+            "HTTP %d fetching Irish IAIP page — EI_ENR_4_4_EN.pdf skipped: %s",
+            exc.code, page_url,
+        )
+        return None
+    except urllib.error.URLError as exc:
+        logger.warning(
+            "Network error fetching Irish IAIP page — EI_ENR_4_4_EN.pdf skipped: %s",
+            exc.reason,
+        )
+        return None
+
+    try:
+        pdf_url, guid = _find_enr44_url(html)
+    except IrishEaipFetchError as exc:
+        logger.warning("%s", exc)
+        return None
+
+    logger.info("Found EI_ENR_4_4_EN.pdf (guid=%s): %s", guid, pdf_url)
+
+    try:
+        _download_pdf(pdf_url, dest_path, timeout=pdf_timeout)
+    except urllib.error.HTTPError as exc:
+        logger.warning(
+            "HTTP %d downloading EI_ENR_4_4_EN.pdf — skipped: %s", exc.code, pdf_url
+        )
+        return None
+    except urllib.error.URLError as exc:
+        logger.warning(
+            "Network error downloading EI_ENR_4_4_EN.pdf — skipped: %s", exc.reason
+        )
+        return None
+    except OSError as exc:
+        logger.warning("I/O error writing EI_ENR_4_4_EN.pdf — skipped: %s", exc)
+        return None
+
+    logger.info(
+        "EI_ENR_4_4_EN.pdf written (%d bytes, guid=%s)",
+        dest_path.stat().st_size, guid,
+    )
+    return dest_path

--- a/src/sources/irish_eaip_pdf.py
+++ b/src/sources/irish_eaip_pdf.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import tempfile
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -152,8 +153,11 @@ def fetch_irish_enr44(
         )
         return None
 
+    parsed = urllib.parse.urlparse(page_url)
+    base_url = f"{parsed.scheme}://{parsed.netloc}"
+
     try:
-        pdf_url, guid = _find_enr44_url(html)
+        pdf_url, guid = _find_enr44_url(html, base_url=base_url)
     except IrishEaipFetchError as exc:
         logger.warning("%s", exc)
         return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 
 from src.airac import cycle_for_date
 from src.cli import _resolve_cycle, cli
-from src.config import Config, EaipConfig, NatsSrdConfig, SourcesConfig, VatsimSctConfig
+from src.config import Config, EaipConfig, IrishEaipConfig, NatsSrdConfig, SourcesConfig, VatsimSctConfig
 from src.processing.excel_to_csv import ExcelValidationError
 from src.sources.eaip_html import EaipFetchError
 from src.sources.nats_srd import SrdFetchError
@@ -45,6 +45,7 @@ def _make_config(tmp_path: Path) -> Config:
             nats_srd=NatsSrdConfig(page_url="", sheet_name="Routes", notes_sheet="Notes"),
             vatsim_sct=VatsimSctConfig(url=""),
             eaip=EaipConfig(page_url="", files=()),
+            irish_eaip=IrishEaipConfig(page_url=""),
         ),
     )
 
@@ -110,6 +111,7 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={"Routes": Path("Routes.csv"), "Notes": Path("Notes.csv")}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44", return_value=Path("EI_ENR_4_4_EN.pdf")),
         ):
             return runner.invoke(cli, ["fetch", "--cycle", "2603"] + (args or []))
 
@@ -246,6 +248,7 @@ class TestFetchCommand:
                 nats_srd=NatsSrdConfig(page_url="", sheet_name="Routes", notes_sheet="Notes"),
                 vatsim_sct=VatsimSctConfig(url=""),
                 eaip=EaipConfig(page_url="https://custom.url/aip", files=()),
+                irish_eaip=IrishEaipConfig(page_url=""),
             ),
         )
         runner = CliRunner()
@@ -258,6 +261,7 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44", return_value=None),
         ):
             runner.invoke(cli, ["fetch", "--cycle", "2603"])
         _, kwargs = mock_eaip.call_args

--- a/tests/test_irish_eaip_pdf.py
+++ b/tests/test_irish_eaip_pdf.py
@@ -1,0 +1,210 @@
+"""Unit tests for src/sources/irish_eaip_pdf.py.
+
+All tests are offline: HTTP is replaced via unittest.mock.patch.
+All filesystem writes go through pytest's tmp_path fixture.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.sources.irish_eaip_pdf import (
+    IrishEaipFetchError,
+    PDF_FILENAME,
+    _BASE_URL,
+    _IAIP_PACKAGE_URL,
+    _find_enr44_url,
+    _fetch_page,
+    fetch_irish_enr44,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+FAKE_GUID = "e3c9008c-779a-425f-84c4-a88425528047"
+FAKE_PDF_URL = f"{_BASE_URL}/getattachment/{FAKE_GUID}/EI_ENR_4_4_EN.pdf?lang=en-IE"
+FAKE_PDF_BYTES = b"%PDF-1.4 fake Irish ENR 4.4 content"
+
+
+def _make_iaip_page(guid: str = FAKE_GUID) -> str:
+    """Return minimal IAIP package HTML containing an ENR 4.4 link."""
+    return (
+        "<html><body>"
+        f'<a href="/getattachment/{guid}/EI_ENR_4_4_EN.pdf?lang=en-IE">ENR 4.4</a>'
+        "</body></html>"
+    )
+
+
+def _patch_fetch_page(html: str):
+    """Patch _fetch_page to return *html*."""
+    return patch("src.sources.irish_eaip_pdf._fetch_page", return_value=html)
+
+
+def _patch_download_pdf(content: bytes = FAKE_PDF_BYTES):
+    """Patch _download_pdf to write *content* to the dest path."""
+    def fake_download(url, dest, timeout=60):
+        dest.write_bytes(content)
+    return patch("src.sources.irish_eaip_pdf._download_pdf", side_effect=fake_download)
+
+
+# ---------------------------------------------------------------------------
+# _find_enr44_url
+# ---------------------------------------------------------------------------
+
+class TestFindEnr44Url:
+    def test_finds_link_in_realistic_html(self):
+        html = _make_iaip_page(FAKE_GUID)
+        url, guid = _find_enr44_url(html)
+        assert guid == FAKE_GUID
+        assert f"getattachment/{FAKE_GUID}/EI_ENR_4_4_EN.pdf" in url
+
+    def test_url_is_absolute(self):
+        html = _make_iaip_page(FAKE_GUID)
+        url, _ = _find_enr44_url(html)
+        assert url.startswith("https://")
+
+    def test_custom_base_url(self):
+        html = _make_iaip_page(FAKE_GUID)
+        url, _ = _find_enr44_url(html, base_url="https://example.com")
+        assert url.startswith("https://example.com")
+
+    def test_different_guid_extracted(self):
+        other_guid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        html = _make_iaip_page(other_guid)
+        _, guid = _find_enr44_url(html)
+        assert guid == other_guid
+
+    def test_link_not_found_raises(self):
+        html = "<html><body><p>No ENR 4.4 here</p></body></html>"
+        with pytest.raises(IrishEaipFetchError, match="Could not find"):
+            _find_enr44_url(html)
+
+    def test_similar_enr_links_not_confused(self):
+        """ENR 4.1, 4.3, 4.5 must not match the ENR 4.4 regex."""
+        html = (
+            "<html><body>"
+            f'<a href="/getattachment/aaa/EI_ENR_4_1_EN.pdf">ENR 4.1</a>'
+            f'<a href="/getattachment/bbb/EI_ENR_4_3_EN.pdf">ENR 4.3</a>'
+            f'<a href="/getattachment/ccc/EI_ENR_4_5_EN.pdf">ENR 4.5</a>'
+            "</body></html>"
+        )
+        with pytest.raises(IrishEaipFetchError):
+            _find_enr44_url(html)
+
+    def test_first_match_used_when_multiple(self):
+        """If the page somehow contains two ENR 4.4 links, the first is used."""
+        html = (
+            "<html><body>"
+            f'<a href="/getattachment/first-guid-aaa/EI_ENR_4_4_EN.pdf">ENR 4.4</a>'
+            f'<a href="/getattachment/second-guid-bbb/EI_ENR_4_4_EN.pdf">ENR 4.4 (2)</a>'
+            "</body></html>"
+        )
+        _, guid = _find_enr44_url(html)
+        assert guid == "first-guid-aaa"
+
+
+# ---------------------------------------------------------------------------
+# fetch_irish_enr44 — success paths
+# ---------------------------------------------------------------------------
+
+class TestFetchIrishEnr44Success:
+    def test_returns_path_on_success(self, tmp_path):
+        html = _make_iaip_page()
+        with _patch_fetch_page(html), _patch_download_pdf():
+            result = fetch_irish_enr44(tmp_path)
+        assert result is not None
+        assert result.name == PDF_FILENAME
+
+    def test_file_written_to_dest_dir(self, tmp_path):
+        html = _make_iaip_page()
+        with _patch_fetch_page(html), _patch_download_pdf():
+            result = fetch_irish_enr44(tmp_path)
+        assert result is not None
+        assert result.parent == tmp_path
+        assert result.exists()
+
+    def test_dest_dir_created_if_missing(self, tmp_path):
+        target = tmp_path / "new" / "subdir"
+        assert not target.exists()
+        html = _make_iaip_page()
+        with _patch_fetch_page(html), _patch_download_pdf():
+            fetch_irish_enr44(target)
+        assert target.is_dir()
+
+    def test_custom_page_url_passed_through(self, tmp_path):
+        """page_url kwarg should be forwarded to _fetch_page."""
+        captured = []
+        def fake_fetch(url, timeout=30):
+            captured.append(url)
+            return _make_iaip_page()
+        with patch("src.sources.irish_eaip_pdf._fetch_page", side_effect=fake_fetch):
+            with _patch_download_pdf():
+                fetch_irish_enr44(tmp_path, page_url="https://custom.example.com/page")
+        assert captured == ["https://custom.example.com/page"]
+
+    def test_default_page_url_is_airnav(self, tmp_path):
+        captured = []
+        def fake_fetch(url, timeout=30):
+            captured.append(url)
+            return _make_iaip_page()
+        with patch("src.sources.irish_eaip_pdf._fetch_page", side_effect=fake_fetch):
+            with _patch_download_pdf():
+                fetch_irish_enr44(tmp_path)
+        assert captured[0] == _IAIP_PACKAGE_URL
+
+
+# ---------------------------------------------------------------------------
+# fetch_irish_enr44 — non-fatal failure paths (returns None, no raise)
+# ---------------------------------------------------------------------------
+
+class TestFetchIrishEnr44NonFatal:
+    def test_http_error_on_page_returns_none(self, tmp_path):
+        err = urllib.error.HTTPError("url", 503, "Service Unavailable", {}, None)
+        with patch("src.sources.irish_eaip_pdf._fetch_page", side_effect=err):
+            result = fetch_irish_enr44(tmp_path)
+        assert result is None
+
+    def test_network_error_on_page_returns_none(self, tmp_path):
+        err = urllib.error.URLError("connection refused")
+        with patch("src.sources.irish_eaip_pdf._fetch_page", side_effect=err):
+            result = fetch_irish_enr44(tmp_path)
+        assert result is None
+
+    def test_link_not_found_returns_none(self, tmp_path):
+        with _patch_fetch_page("<html><p>no link</p></html>"):
+            result = fetch_irish_enr44(tmp_path)
+        assert result is None
+
+    def test_http_error_on_pdf_download_returns_none(self, tmp_path):
+        err = urllib.error.HTTPError("url", 404, "Not Found", {}, None)
+        html = _make_iaip_page()
+        with _patch_fetch_page(html):
+            with patch("src.sources.irish_eaip_pdf._download_pdf", side_effect=err):
+                result = fetch_irish_enr44(tmp_path)
+        assert result is None
+
+    def test_network_error_on_pdf_download_returns_none(self, tmp_path):
+        err = urllib.error.URLError("timeout")
+        html = _make_iaip_page()
+        with _patch_fetch_page(html):
+            with patch("src.sources.irish_eaip_pdf._download_pdf", side_effect=err):
+                result = fetch_irish_enr44(tmp_path)
+        assert result is None
+
+    def test_oserror_on_pdf_write_returns_none(self, tmp_path):
+        html = _make_iaip_page()
+        with _patch_fetch_page(html):
+            with patch("src.sources.irish_eaip_pdf._download_pdf", side_effect=OSError("disk full")):
+                result = fetch_irish_enr44(tmp_path)
+        assert result is None
+
+    def test_no_partial_file_left_on_page_failure(self, tmp_path):
+        err = urllib.error.URLError("offline")
+        with patch("src.sources.irish_eaip_pdf._fetch_page", side_effect=err):
+            fetch_irish_enr44(tmp_path)
+        assert not (tmp_path / PDF_FILENAME).exists()

--- a/tests/test_irish_eaip_pdf.py
+++ b/tests/test_irish_eaip_pdf.py
@@ -157,6 +157,24 @@ class TestFetchIrishEnr44Success:
                 fetch_irish_enr44(tmp_path)
         assert captured[0] == _IAIP_PACKAGE_URL
 
+    def test_pdf_url_uses_same_origin_as_page_url(self, tmp_path):
+        """PDF must be downloaded from the same origin as the overridden page_url.
+
+        Regression test for the gap identified in PR review: _find_enr44_url()
+        was called without a base derived from page_url, so the PDF always
+        downloaded from _BASE_URL (airnav.ie) even when page_url was overridden.
+        """
+        captured_pdf_urls = []
+        def fake_download(url, dest, timeout=60):
+            captured_pdf_urls.append(url)
+            dest.write_bytes(b"pdf")
+        html = _make_iaip_page(FAKE_GUID)
+        with _patch_fetch_page(html):
+            with patch("src.sources.irish_eaip_pdf._download_pdf", side_effect=fake_download):
+                fetch_irish_enr44(tmp_path, page_url="https://mirror.example.com/some/path")
+        assert len(captured_pdf_urls) == 1
+        assert captured_pdf_urls[0].startswith("https://mirror.example.com")
+
 
 # ---------------------------------------------------------------------------
 # fetch_irish_enr44 — non-fatal failure paths (returns None, no raise)


### PR DESCRIPTION
## Summary

- New module `src/sources/irish_eaip_pdf.py` scrapes the [AirNav Ireland IAIP package page](https://www.airnav.ie/air-traffic-management/aeronautical-information-management/aip-package) to find the current GUID-based link for `EI_ENR_4_4_EN.pdf`, then downloads it atomically into the cycle working directory
- Non-fatal by design (acceptance criterion 3): every error path logs a warning and returns `None` — the overall fetch pipeline is not aborted
- The GUID logged at download time surfaces mid-cycle document replacements (AirNav occasionally issues interim amendments without changing the cycle effective date)
- New `IrishEaipConfig` dataclass in `config.py`; `page_url` in `config.yaml` is overridable for testing or if AirNav moves the page
- Step 7 added to `cli.py`; step total bumped from 6 to 7

## Technical note on URL discovery

The Irish AIP uses GUID-based attachment URLs (`/getattachment/{guid}/EI_ENR_4_4_EN.pdf`) that change each cycle. The GUID is present in the **static HTML** of the IAIP package page — no JS rendering required, confirmed by direct HTTP fetch during development. The regex `getattachment/([\w\-]+)/EI_ENR_4_4_EN\.pdf` reliably extracts it.

## Tests

- `tests/test_irish_eaip_pdf.py`: 19 tests covering URL extraction (correct GUID, wrong filename not matched, multiple links, missing link), success paths (file written, dest dir created, custom URL forwarded), and all non-fatal failure paths (HTTP error on page, network error on page, link not found, HTTP error on PDF, network error on PDF, OS error on write)
- `tests/test_cli.py`: updated `SourcesConfig` fixture and `_invoke` helper to include `IrishEaipConfig` and mock `fetch_irish_enr44`
- **255 passed, 0 failed**

## Rules database

- New rule `RULE:IRISH-EAIP-ENR44-URL` registered in `vFPC-Hub/Documentation/rules_reference.json` (44 rules total)

Closes #10