### PR TITLE
Fetch Irish and French ENR 4.4 support HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ For a given AIRAC cycle, the tool:
 3. Downloads the UK eAIP HTML files needed by downstream tools
 4. Downloads the NATS SRD workbook and converts it to `Routes.csv` and `Notes.csv`
 5. Downloads the VATSIM UK sector file (`.sct`)
-6. Attempts to fetch the Irish ENR 4.4 PDF as a non-fatal support input
+6. Attempts to fetch Irish and French ENR 4.4 HTML as non-fatal support inputs
+7. Attempts to fetch the Irish ENR 4.4 PDF as a non-fatal support input
 
 After `fetch` completes:
 
@@ -77,7 +78,10 @@ sources:
       - "EG-ENR-4.2-en-GB.html"
       - "EG-ENR-4.4-en-GB.html"
   irish_eaip:
+    html_base_url: "https://..."  # AirNav Ireland eAIP HTML cycle base
     page_url:    "https://..."  # AirNav Ireland IAIP package page
+  french_eaip:
+    base_url:    "https://..."  # SIA France eAIP DVD base
 ```
 
 ---
@@ -118,6 +122,8 @@ python -m src fetch
 | `UK_YYYY_NN.sct` | VATSIM-UK uk-controller-pack release |
 | `Routes.csv` | Converted from the NATS SRD Excel workbook |
 | `Notes.csv` | Converted from the NATS SRD Excel workbook |
+| `EI-ENR-4.4-en-IE.html` | AirNav Ireland eAIP cycle HTML fetch, when available |
+| `FR-ENR-4.4-fr-FR.html` | SIA France eAIP cycle HTML fetch, when available |
 | `EI_ENR_4_4_EN.pdf` | Irish IAIP package page fetch, when available |
 
 ---
@@ -165,6 +171,10 @@ After download, the "What's New" sheet header is read and the embedded date is v
 
 The GitHub releases API for `VATSIM-UK/uk-controller-pack` is queried. The most recently published release whose tag matches `{YYYY}_{NN}[a-z]*` is selected (latest patch letter wins). The `.sct` file is extracted from `UK/data/UK_{YYYY}_{NN}.sct` inside the source archive. [`RULE:SCT-RELEASE-TAG`] [`RULE:SCT-FILE-PATH`]
 
+### Foreign ENR 4.4 support files
+
+Irish and French ENR 4.4 HTML files are fetched from deterministic cycle paths based on the AIRAC effective date. They support FIR-boundary and foreign-FRA evidence work downstream. These fetches are non-fatal because the foreign AIP pages can lag during cycle turnover. [`RULE:IRISH-EAIP-ENR44-HTML-URL`] [`RULE:FRENCH-EAIP-ENR44-HTML-URL`]
+
 ---
 
 ## Error messages
@@ -200,6 +210,7 @@ src/
   __main__.py               `python -m src` entry point
   sources/
     eaip_html.py            NATS AIP HTML fetcher
+    foreign_enr44_html.py   Irish/French ENR 4.4 HTML support-file fetcher
     irish_eaip_pdf.py       Irish ENR 4.4 PDF fetcher
     nats_srd.py             NATS SRD Excel fetcher
     vatsim_sct.py           VATSIM UK SCT fetcher

--- a/config.yaml
+++ b/config.yaml
@@ -36,8 +36,17 @@ sources:
       - "EG-ENR-4.2-en-GB.html"
       - "EG-ENR-4.4-en-GB.html"
   irish_eaip:
+    # AirNav Ireland cycle eAIP HTML directory. ENR 4.4 is fetched as:
+    # {html_base_url}/{YYYY-MM-DD}-AIRAC/html/eAIP/EI-ENR-4.4-en-IE.html
+    # [RULE:IRISH-EAIP-ENR44-HTML-URL]
+    html_base_url: "https://www.airnav.ie/AIRAC"
     # AirNav Ireland IAIP package page. ENR 4.4 PDF link is scraped from here
     # each cycle — the GUID in the download URL changes when AirNav updates the
     # document. Override if the page URL moves. [RULE:IRISH-EAIP-ENR44-URL]
     # Confirmed working 2026-03-31.
     page_url: "https://www.airnav.ie/air-traffic-management/aeronautical-information-management/aip-package"
+  french_eaip:
+    # SIA France eAIP DVD base. ENR 4.4 is fetched as:
+    # {base_url}/eAIP_DD_MMM_YYYY/FRANCE/AIRAC-YYYY-MM-DD/html/eAIP/FR-ENR-4.4-fr-FR.html
+    # [RULE:FRENCH-EAIP-ENR44-HTML-URL]
+    base_url: "https://www.sia.aviation-civile.gouv.fr/media/dvd"

--- a/src/cli.py
+++ b/src/cli.py
@@ -18,7 +18,8 @@ fetch
     4. Fetch the SRD Excel zip from NATS and extract the .xlsx file.
     5. Validate and convert the SRD Excel to Routes.csv and Notes.csv.
     6. Fetch the VATSIM UK sector file (.sct) from the uk-controller-pack release.
-    7. Fetch EI_ENR_4_4_EN.pdf from the AirNav Ireland IAIP package page (non-fatal).
+    7. Fetch Irish and French ENR 4.4 HTML support files (non-fatal).
+    8. Fetch EI_ENR_4_4_EN.pdf from the AirNav Ireland IAIP package page (non-fatal).
 
 After fetching, run the SRD Parser to produce out.json, then use the
 airac-archiver tool to package and stage the files: https://github.com/VFPC/airac-archiver
@@ -38,6 +39,10 @@ from src.airac import AiracCycle, current_cycle, cycle_for_date
 from src.config import ConfigError, load
 from src.processing.excel_to_csv import ExcelValidationError, convert_srd_excel
 from src.sources.eaip_html import EaipFetchError, fetch_eaip_html
+from src.sources.foreign_enr44_html import (
+    fetch_french_enr44_html,
+    fetch_irish_enr44_html,
+)
 from src.sources.irish_eaip_pdf import fetch_irish_enr44
 from src.sources.nats_srd import SrdFetchError, fetch_srd
 from src.sources.vatsim_sct import SctFetchError, fetch_sct
@@ -172,7 +177,7 @@ def fetch(cycle: str | None) -> None:
     click.echo(f"\nCycle:     {target}")
     click.echo(f"Directory: {work_dir}\n")
 
-    total = 7
+    total = 8
 
     # Step 1 — working directory
     _step(1, total, "Creating working directory")
@@ -232,8 +237,27 @@ def fetch(cycle: str | None) -> None:
     except SctFetchError as exc:
         _abort(str(exc))
 
-    # Step 7 — Irish ENR 4.4 PDF (non-fatal: warns and continues if unavailable)
-    _step(7, total, "Fetching Irish eAIP ENR 4.4 PDF (EI_ENR_4_4_EN.pdf)")
+    # Step 7 — foreign ENR 4.4 HTML (non-fatal: warns and continues if unavailable)
+    _step(7, total, "Fetching Irish/French ENR 4.4 HTML")
+    kwargs_irish_html: dict = {}
+    if cfg.sources.irish_eaip.html_base_url:
+        kwargs_irish_html["base_url"] = cfg.sources.irish_eaip.html_base_url
+    kwargs_french_html: dict = {}
+    if cfg.sources.french_eaip.base_url:
+        kwargs_french_html["base_url"] = cfg.sources.french_eaip.base_url
+
+    irish_html = fetch_irish_enr44_html(target, work_dir, **kwargs_irish_html)
+    french_html = fetch_french_enr44_html(target, work_dir, **kwargs_french_html)
+    html_names = [p.name for p in (irish_html, french_html) if p]
+    if html_names:
+        _ok(", ".join(html_names))
+        cli_logger.info("Foreign ENR 4.4 HTML files written: %s", ", ".join(html_names))
+    else:
+        click.echo(" skipped (unavailable - see log for details)")
+        cli_logger.warning("Foreign ENR 4.4 HTML fetches skipped - check log for details")
+
+    # Step 8 — Irish ENR 4.4 PDF (non-fatal: warns and continues if unavailable)
+    _step(8, total, "Fetching Irish eAIP ENR 4.4 PDF (EI_ENR_4_4_EN.pdf)")
     kwargs_ie: dict = {}
     if cfg.sources.irish_eaip.page_url:
         kwargs_ie["page_url"] = cfg.sources.irish_eaip.page_url

--- a/src/config.py
+++ b/src/config.py
@@ -40,6 +40,12 @@ class EaipConfig:
 @dataclass(frozen=True)
 class IrishEaipConfig:
     page_url: str
+    html_base_url: str = ""
+
+
+@dataclass(frozen=True)
+class FrenchEaipConfig:
+    base_url: str = ""
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,7 @@ class SourcesConfig:
     vatsim_sct: VatsimSctConfig
     eaip: EaipConfig
     irish_eaip: IrishEaipConfig
+    french_eaip: FrenchEaipConfig
 
 
 @dataclass(frozen=True)
@@ -108,6 +115,12 @@ def _parse(raw: dict) -> Config:
     irish = src.get("irish_eaip") or {}
     irish_eaip_cfg = IrishEaipConfig(
         page_url=irish.get("page_url") or "",
+        html_base_url=irish.get("html_base_url") or "",
+    )
+
+    french = src.get("french_eaip") or {}
+    french_eaip_cfg = FrenchEaipConfig(
+        base_url=french.get("base_url") or "",
     )
 
     return Config(
@@ -117,6 +130,7 @@ def _parse(raw: dict) -> Config:
             vatsim_sct=vatsim_sct,
             eaip=eaip_cfg,
             irish_eaip=irish_eaip_cfg,
+            french_eaip=french_eaip_cfg,
         ),
     )
 

--- a/src/sources/foreign_enr44_html.py
+++ b/src/sources/foreign_enr44_html.py
@@ -1,0 +1,132 @@
+"""Fetch non-UK ENR 4.4 HTML support files for FIR-boundary evidence.
+
+These files are source inputs for downstream SRD/AIP reconciliation work. They
+are deliberately non-fatal: foreign AIP publication pages can lag briefly during
+AIRAC turnover, and a missing support file must not block the UK source fetch.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from src.airac import AiracCycle
+
+logger = logging.getLogger(__name__)
+
+# [RULE:IRISH-EAIP-ENR44-HTML-URL]
+IRISH_HTML_BASE_URL = "https://www.airnav.ie/AIRAC"
+# [RULE:FRENCH-EAIP-ENR44-HTML-URL]
+FRENCH_HTML_BASE_URL = "https://www.sia.aviation-civile.gouv.fr/media/dvd"
+
+IRISH_ENR44_HTML_FILENAME = "EI-ENR-4.4-en-IE.html"
+FRENCH_ENR44_HTML_FILENAME = "FR-ENR-4.4-fr-FR.html"
+_MONTH_TOKENS = (
+    "JAN",
+    "FEB",
+    "MAR",
+    "APR",
+    "MAY",
+    "JUN",
+    "JUL",
+    "AUG",
+    "SEP",
+    "OCT",
+    "NOV",
+    "DEC",
+)
+
+
+def _strip_slash(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _french_date_token(cycle: AiracCycle) -> str:
+    effective = cycle.effective_date
+    return f"{effective.day:02d}_{_MONTH_TOKENS[effective.month - 1]}_{effective.year}"
+
+
+def _irish_enr44_url(
+    cycle: AiracCycle,
+    base_url: str = IRISH_HTML_BASE_URL,
+) -> str:
+    """Return the AirNav Ireland cycle ENR 4.4 HTML URL for *cycle*."""
+    effective = cycle.effective_date.isoformat()
+    return (
+        f"{_strip_slash(base_url)}/{effective}-AIRAC/html/eAIP/"
+        f"{IRISH_ENR44_HTML_FILENAME}"
+    )
+
+
+def _french_enr44_url(
+    cycle: AiracCycle,
+    base_url: str = FRENCH_HTML_BASE_URL,
+) -> str:
+    """Return the SIA France cycle ENR 4.4 HTML URL for *cycle*."""
+    effective = cycle.effective_date.isoformat()
+    return (
+        f"{_strip_slash(base_url)}/eAIP_{_french_date_token(cycle)}"
+        f"/FRANCE/AIRAC-{effective}/html/eAIP/{FRENCH_ENR44_HTML_FILENAME}"
+    )
+
+
+def _download_html(url: str, dest: Path, timeout: int = 60) -> None:
+    """Download text/html from *url* and write it atomically to *dest*."""
+    tmp_path = dest.with_suffix(dest.suffix + ".tmp")
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            tmp_path.write_bytes(resp.read())
+        shutil.move(str(tmp_path), str(dest))
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _fetch_enr44_html(url: str, dest: Path, label: str, timeout: int = 60) -> Path | None:
+    try:
+        _download_html(url, dest, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        logger.warning("HTTP %d fetching %s ENR 4.4 HTML - skipped: %s", exc.code, label, url)
+        return None
+    except urllib.error.URLError as exc:
+        logger.warning("Network error fetching %s ENR 4.4 HTML - skipped: %s", label, exc.reason)
+        return None
+    except OSError as exc:
+        logger.warning("I/O error writing %s ENR 4.4 HTML - skipped: %s", label, exc)
+        return None
+
+    logger.info("%s ENR 4.4 HTML written to %s (%d bytes)", label, dest, dest.stat().st_size)
+    return dest
+
+
+def fetch_irish_enr44_html(
+    cycle: AiracCycle,
+    dest_dir: Path,
+    *,
+    base_url: str = IRISH_HTML_BASE_URL,
+    timeout: int = 60,
+) -> Path | None:
+    """Fetch EI-ENR-4.4-en-IE.html for *cycle* into *dest_dir*."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    url = _irish_enr44_url(cycle, base_url=base_url)
+    dest = dest_dir / IRISH_ENR44_HTML_FILENAME
+    logger.info("Fetching Irish ENR 4.4 HTML: %s", url)
+    return _fetch_enr44_html(url, dest, "Irish", timeout=timeout)
+
+
+def fetch_french_enr44_html(
+    cycle: AiracCycle,
+    dest_dir: Path,
+    *,
+    base_url: str = FRENCH_HTML_BASE_URL,
+    timeout: int = 60,
+) -> Path | None:
+    """Fetch FR-ENR-4.4-fr-FR.html for *cycle* into *dest_dir*."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    url = _french_enr44_url(cycle, base_url=base_url)
+    dest = dest_dir / FRENCH_ENR44_HTML_FILENAME
+    logger.info("Fetching French ENR 4.4 HTML: %s", url)
+    return _fetch_enr44_html(url, dest, "French", timeout=timeout)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,15 @@ from click.testing import CliRunner
 
 from src.airac import cycle_for_date
 from src.cli import _resolve_cycle, cli
-from src.config import Config, EaipConfig, IrishEaipConfig, NatsSrdConfig, SourcesConfig, VatsimSctConfig
+from src.config import (
+    Config,
+    EaipConfig,
+    FrenchEaipConfig,
+    IrishEaipConfig,
+    NatsSrdConfig,
+    SourcesConfig,
+    VatsimSctConfig,
+)
 from src.processing.excel_to_csv import ExcelValidationError
 from src.sources.eaip_html import EaipFetchError
 from src.sources.nats_srd import SrdFetchError
@@ -46,6 +54,7 @@ def _make_config(tmp_path: Path) -> Config:
             vatsim_sct=VatsimSctConfig(url=""),
             eaip=EaipConfig(page_url="", files=()),
             irish_eaip=IrishEaipConfig(page_url=""),
+            french_eaip=FrenchEaipConfig(base_url=""),
         ),
     )
 
@@ -111,6 +120,8 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={"Routes": Path("Routes.csv"), "Notes": Path("Notes.csv")}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44_html", return_value=Path("EI-ENR-4.4-en-IE.html")),
+            patch("src.cli.fetch_french_enr44_html", return_value=Path("FR-ENR-4.4-fr-FR.html")),
             patch("src.cli.fetch_irish_enr44", return_value=Path("EI_ENR_4_4_EN.pdf")),
         ):
             return runner.invoke(cli, ["fetch", "--cycle", "2603"] + (args or []))
@@ -215,6 +226,9 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44_html", return_value=None),
+            patch("src.cli.fetch_french_enr44_html", return_value=None),
+            patch("src.cli.fetch_irish_enr44", return_value=None),
         ):
             result = runner.invoke(cli, ["fetch", "--cycle", "2603"])
         assert "copied" in result.output
@@ -236,6 +250,9 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44_html", return_value=None),
+            patch("src.cli.fetch_french_enr44_html", return_value=None),
+            patch("src.cli.fetch_irish_enr44", return_value=None),
         ):
             result = runner.invoke(cli, ["fetch"])
         assert "2603" in result.output
@@ -249,6 +266,7 @@ class TestFetchCommand:
                 vatsim_sct=VatsimSctConfig(url=""),
                 eaip=EaipConfig(page_url="https://custom.url/aip", files=()),
                 irish_eaip=IrishEaipConfig(page_url=""),
+                french_eaip=FrenchEaipConfig(base_url=""),
             ),
         )
         runner = CliRunner()
@@ -261,6 +279,8 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44_html", return_value=None),
+            patch("src.cli.fetch_french_enr44_html", return_value=None),
             patch("src.cli.fetch_irish_enr44", return_value=None),
         ):
             runner.invoke(cli, ["fetch", "--cycle", "2603"])
@@ -279,10 +299,51 @@ class TestFetchCommand:
             patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
             patch("src.cli.convert_srd_excel", return_value={}),
             patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44_html", return_value=None),
+            patch("src.cli.fetch_french_enr44_html", return_value=None),
+            patch("src.cli.fetch_irish_enr44", return_value=None),
         ):
             runner.invoke(cli, ["fetch", "--cycle", "2603"])
         _, kwargs = mock_eaip.call_args
         assert "index_url" not in kwargs
+
+    def test_foreign_enr44_base_urls_from_config_passed_through(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        cfg = Config(
+            workspace_base=cfg.workspace_base,
+            sources=SourcesConfig(
+                nats_srd=NatsSrdConfig(page_url="", sheet_name="Routes", notes_sheet="Notes"),
+                vatsim_sct=VatsimSctConfig(url=""),
+                eaip=EaipConfig(page_url="", files=()),
+                irish_eaip=IrishEaipConfig(
+                    page_url="",
+                    html_base_url="https://irish.example/AIRAC",
+                ),
+                french_eaip=FrenchEaipConfig(
+                    base_url="https://french.example/media/dvd",
+                ),
+            ),
+        )
+        runner = CliRunner()
+        excel_path = tmp_path / "SRD.xlsx"
+        with (
+            patch("src.cli.load", return_value=cfg),
+            patch("src.cli.ensure_cycle_dir"),
+            patch("src.cli.copy_in_json_forward", return_value=None),
+            patch("src.cli.fetch_eaip_html", return_value={}),
+            patch("src.cli.fetch_srd", return_value={"SRD.xlsx": excel_path}),
+            patch("src.cli.convert_srd_excel", return_value={}),
+            patch("src.cli.fetch_sct", return_value=Path("UK_2026_03.sct")),
+            patch("src.cli.fetch_irish_enr44_html", return_value=None) as mock_irish,
+            patch("src.cli.fetch_french_enr44_html", return_value=None) as mock_french,
+            patch("src.cli.fetch_irish_enr44", return_value=None),
+        ):
+            runner.invoke(cli, ["fetch", "--cycle", "2603"])
+
+        _, irish_kwargs = mock_irish.call_args
+        _, french_kwargs = mock_french.call_args
+        assert irish_kwargs.get("base_url") == "https://irish.example/AIRAC"
+        assert french_kwargs.get("base_url") == "https://french.example/media/dvd"
 
     def test_log_file_created_on_success(self, tmp_path):
         result = self._invoke(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,11 @@ sources:
     files:
       - EG-ENR-3.2-en-GB.html
       - EG-ENR-3.3-en-GB.html
+  irish_eaip:
+    page_url: ""
+    html_base_url: ""
+  french_eaip:
+    base_url: ""
 """
 
 
@@ -62,6 +67,8 @@ class TestLoad:
         assert cfg.sources.nats_srd.page_url == ""
         assert cfg.sources.vatsim_sct.url == ""
         assert cfg.sources.eaip.page_url == ""
+        assert cfg.sources.irish_eaip.html_base_url == ""
+        assert cfg.sources.french_eaip.base_url == ""
 
     def test_file_not_found_raises(self, tmp_path):
         with pytest.raises(ConfigError, match="not found"):

--- a/tests/test_foreign_enr44_html.py
+++ b/tests/test_foreign_enr44_html.py
@@ -1,0 +1,95 @@
+"""Tests for non-UK ENR 4.4 HTML support-file fetches."""
+
+from __future__ import annotations
+
+import urllib.error
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+from src.airac import cycle_for_date
+from src.sources.foreign_enr44_html import (
+    FRENCH_ENR44_HTML_FILENAME,
+    IRISH_ENR44_HTML_FILENAME,
+    _french_enr44_url,
+    _irish_enr44_url,
+    fetch_french_enr44_html,
+    fetch_irish_enr44_html,
+)
+
+CYCLE_2603 = cycle_for_date(date(2026, 3, 19))
+
+
+def test_irish_enr44_url_uses_cycle_effective_date():
+    assert _irish_enr44_url(CYCLE_2603, "https://www.airnav.ie/AIRAC") == (
+        "https://www.airnav.ie/AIRAC/2026-03-19-AIRAC/html/eAIP/"
+        "EI-ENR-4.4-en-IE.html"
+    )
+
+
+def test_french_enr44_url_uses_sia_dvd_cycle_path():
+    assert _french_enr44_url(
+        CYCLE_2603,
+        "https://www.sia.aviation-civile.gouv.fr/media/dvd",
+    ) == (
+        "https://www.sia.aviation-civile.gouv.fr/media/dvd/eAIP_19_MAR_2026"
+        "/FRANCE/AIRAC-2026-03-19/html/eAIP/FR-ENR-4.4-fr-FR.html"
+    )
+
+
+def test_fetch_irish_enr44_html_writes_expected_file(tmp_path):
+    def fake_download(url: str, dest: Path, timeout: int = 60) -> None:
+        dest.write_text(f"<html>{url}</html>", encoding="utf-8")
+
+    with patch("src.sources.foreign_enr44_html._download_html", side_effect=fake_download):
+        result = fetch_irish_enr44_html(
+            CYCLE_2603,
+            tmp_path,
+            base_url="https://irish.example/AIRAC",
+        )
+
+    assert result == tmp_path / IRISH_ENR44_HTML_FILENAME
+    assert "https://irish.example/AIRAC/2026-03-19-AIRAC" in result.read_text(encoding="utf-8")
+
+
+def test_fetch_french_enr44_html_writes_expected_file(tmp_path):
+    def fake_download(url: str, dest: Path, timeout: int = 60) -> None:
+        dest.write_text(f"<html>{url}</html>", encoding="utf-8")
+
+    with patch("src.sources.foreign_enr44_html._download_html", side_effect=fake_download):
+        result = fetch_french_enr44_html(
+            CYCLE_2603,
+            tmp_path,
+            base_url="https://french.example/media/dvd",
+        )
+
+    assert result == tmp_path / FRENCH_ENR44_HTML_FILENAME
+    assert "https://french.example/media/dvd/eAIP_19_MAR_2026" in result.read_text(encoding="utf-8")
+
+
+def test_fetch_irish_enr44_html_returns_none_on_http_error(tmp_path):
+    err = urllib.error.HTTPError("https://example.test", 404, "not found", hdrs=None, fp=None)
+
+    with patch("src.sources.foreign_enr44_html._download_html", side_effect=err):
+        result = fetch_irish_enr44_html(CYCLE_2603, tmp_path)
+
+    assert result is None
+    assert not (tmp_path / IRISH_ENR44_HTML_FILENAME).exists()
+
+
+def test_fetch_french_enr44_html_returns_none_on_url_error(tmp_path):
+    err = urllib.error.URLError("connection refused")
+
+    with patch("src.sources.foreign_enr44_html._download_html", side_effect=err):
+        result = fetch_french_enr44_html(CYCLE_2603, tmp_path)
+
+    assert result is None
+    assert not (tmp_path / FRENCH_ENR44_HTML_FILENAME).exists()
+
+
+def test_fetch_french_enr44_html_returns_none_on_io_error(tmp_path):
+    with patch("src.sources.foreign_enr44_html._download_html", side_effect=OSError("disk full")):
+        result = fetch_french_enr44_html(CYCLE_2603, tmp_path)
+
+    assert result is None
+    assert not (tmp_path / FRENCH_ENR44_HTML_FILENAME).exists()


### PR DESCRIPTION
Closes #20.\n\n## Summary\n- add non-fatal Irish and French ENR 4.4 HTML fetches for AIRAC cycle work directories\n- add config overrides for AirNav Ireland HTML base and SIA France eAIP DVD base\n- document the new support files and cover URL construction, failures, and CLI config pass-through\n\n## Tests\n- python -m pytest tests/test_foreign_enr44_html.py tests/test_cli.py tests/test_config.py\n- python -m pytest *(fails only in tests/test_rules_db.py because sibling vFPC-Hub rules_reference.md attributes [RULE:EAIP-ENR21-UK] and [RULE:EAIP-ENR22-UK] to this repo, but those tags are absent from src/; unrelated to this change)*