### PR TITLE
Add ENR 2.1 and ENR 2.2 source rule tags

### DIFF
--- a/src/sources/eaip_html.py
+++ b/src/sources/eaip_html.py
@@ -13,6 +13,8 @@ containing all eAIP pages for that cycle.
 Once the zip is downloaded:
 
 Required files (error if missing):
+  - EG-ENR-2.1-en-GB.html
+  - EG-ENR-2.2-en-GB.html
   - EG-ENR-3.2-en-GB.html
   - EG-ENR-3.3-en-GB.html
   - EG-ENR-4.1-en-GB.html
@@ -57,8 +59,8 @@ _LINK_TEXT = "Offline HTML Download"  # exact anchor text to match
 
 # Required files: error if any are missing from the zip (matched by basename)
 _TARGET_BASENAMES = frozenset([
-    "EG-ENR-2.1-en-GB.html",  # ATS airspace (FIR, UIR, TMA, CTA, CTR) — feeds aip_airspaces.json
-    "EG-ENR-2.2-en-GB.html",  # Other regulated airspace (ATZ, MATZ, etc.) — feeds aip_airspaces.json
+    "EG-ENR-2.1-en-GB.html",  # [RULE:EAIP-ENR21-UK] ATS airspace (FIR, UIR, TMA, CTA, CTR) — feeds aip_airspaces.json
+    "EG-ENR-2.2-en-GB.html",  # [RULE:EAIP-ENR22-UK] Other regulated airspace (ATZ, MATZ, etc.) — feeds aip_airspaces.json
     "EG-ENR-3.2-en-GB.html",
     "EG-ENR-3.3-en-GB.html",
     "EG-ENR-4.1-en-GB.html",
@@ -374,8 +376,8 @@ def fetch_eaip_html(
 ) -> dict[str, Path]:
     """Download and extract eAIP HTML files for *cycle*.
 
-    Extracts five required ENR files (ENR 3.2, 3.3, 4.1, 4.2, 4.4) plus all
-    AD 2.2 aerodrome pages found in the zip.
+    Extracts all required ENR files listed in _TARGET_BASENAMES plus all AD 2.2
+    aerodrome pages found in the zip.
 
     Args:
         cycle:         The target AIRAC cycle.


### PR DESCRIPTION
Closes #22.\n\n## Summary\n- add [RULE:EAIP-ENR21-UK] and [RULE:EAIP-ENR22-UK] beside the required ENR 2.1 / ENR 2.2 eAIP filenames in eaip_html.py\n- update stale fetch_eaip_html wording that still described the old five-file ENR required set\n\n## Tests\n- python -m pytest tests/test_rules_db.py tests/test_eaip_html.py\n- python -m pytest *(264 passed, with sibling vFPC-Hub branch codex/register-foreign-enr44-rule-tags checked out)*\n\n## Note\nThe full rules DB validation also requires VFPC/vFPC-vFPC-Hub#158, which registers the foreign ENR 4.4 HTML URL tags introduced by airac-data-fetcher#21.