### PR TITLE
Discover foreign ENR 4.4 links from provider pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ sources:
       - "EG-ENR-4.2-en-GB.html"
       - "EG-ENR-4.4-en-GB.html"
   irish_eaip:
-    html_base_url: "https://..."  # AirNav Ireland eAIP HTML cycle base
+    html_base_url: "https://..."  # AirNav Ireland AIRAC portal base
     page_url:    "https://..."  # AirNav Ireland IAIP package page
   french_eaip:
     base_url:    "https://..."  # SIA France eAIP DVD base
@@ -173,7 +173,7 @@ The GitHub releases API for `VATSIM-UK/uk-controller-pack` is queried. The most 
 
 ### Foreign ENR 4.4 support files
 
-Irish and French ENR 4.4 HTML files are fetched from deterministic cycle paths based on the AIRAC effective date. They support FIR-boundary and foreign-FRA evidence work downstream. These fetches are non-fatal because the foreign AIP pages can lag during cycle turnover. [`RULE:IRISH-EAIP-ENR44-HTML-URL`] [`RULE:FRENCH-EAIP-ENR44-HTML-URL`]
+Irish and French ENR 4.4 HTML files are fetched only after the provider's publication page exposes the target AIRAC cycle. AirNav Ireland is discovered from its AIRAC portal; SIA France is discovered from its eAIP product listing before the ENR 4.4 HTML path is derived. This prevents rehearsal runs for a future AIRAC from accidentally pulling the current cycle's foreign data. These fetches are non-fatal because the foreign AIP pages can lag during cycle turnover. [`RULE:IRISH-EAIP-ENR44-HTML-URL`] [`RULE:FRENCH-EAIP-ENR44-HTML-URL`]
 
 ---
 

--- a/config.yaml
+++ b/config.yaml
@@ -36,8 +36,8 @@ sources:
       - "EG-ENR-4.2-en-GB.html"
       - "EG-ENR-4.4-en-GB.html"
   irish_eaip:
-    # AirNav Ireland cycle eAIP HTML directory. ENR 4.4 is fetched as:
-    # {html_base_url}/{YYYY-MM-DD}-AIRAC/html/eAIP/EI-ENR-4.4-en-IE.html
+    # AirNav Ireland AIRAC portal base. The fetcher reads {html_base_url}/index.html
+    # and follows the eAIP pointer for the target cycle before fetching ENR 4.4.
     # [RULE:IRISH-EAIP-ENR44-HTML-URL]
     html_base_url: "https://www.airnav.ie/AIRAC"
     # AirNav Ireland IAIP package page. ENR 4.4 PDF link is scraped from here
@@ -46,7 +46,8 @@ sources:
     # Confirmed working 2026-03-31.
     page_url: "https://www.airnav.ie/air-traffic-management/aeronautical-information-management/aip-package"
   french_eaip:
-    # SIA France eAIP DVD base. ENR 4.4 is fetched as:
-    # {base_url}/eAIP_DD_MMM_YYYY/FRANCE/AIRAC-YYYY-MM-DD/html/eAIP/FR-ENR-4.4-fr-FR.html
+    # SIA France eAIP DVD base. The fetcher first checks the SIA eAIP product
+    # listing for the target AIRAC cycle, then derives the ENR 4.4 HTML path
+    # from the published cycle date.
     # [RULE:FRENCH-EAIP-ENR44-HTML-URL]
     base_url: "https://www.sia.aviation-civile.gouv.fr/media/dvd"

--- a/src/sources/foreign_enr44_html.py
+++ b/src/sources/foreign_enr44_html.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import logging
 import shutil
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
+
+from bs4 import BeautifulSoup
 
 from src.airac import AiracCycle
 
@@ -21,6 +24,10 @@ logger = logging.getLogger(__name__)
 IRISH_HTML_BASE_URL = "https://www.airnav.ie/AIRAC"
 # [RULE:FRENCH-EAIP-ENR44-HTML-URL]
 FRENCH_HTML_BASE_URL = "https://www.sia.aviation-civile.gouv.fr/media/dvd"
+FRENCH_EAIP_PRODUCTS_URL = (
+    "https://www.sia.aviation-civile.gouv.fr"
+    "/produits-numeriques-en-libre-disposition/eaip.html"
+)
 
 IRISH_ENR44_HTML_FILENAME = "EI-ENR-4.4-en-IE.html"
 FRENCH_ENR44_HTML_FILENAME = "FR-ENR-4.4-fr-FR.html"
@@ -38,6 +45,10 @@ _MONTH_TOKENS = (
     "NOV",
     "DEC",
 )
+
+
+class Enr44HtmlLinkNotFound(Exception):
+    """Raised when a provider page does not expose the target cycle's ENR 4.4 link."""
 
 
 def _strip_slash(url: str) -> str:
@@ -61,6 +72,10 @@ def _irish_enr44_url(
     )
 
 
+def _irish_portal_url(base_url: str = IRISH_HTML_BASE_URL) -> str:
+    return f"{_strip_slash(base_url)}/index.html"
+
+
 def _french_enr44_url(
     cycle: AiracCycle,
     base_url: str = FRENCH_HTML_BASE_URL,
@@ -71,6 +86,111 @@ def _french_enr44_url(
         f"{_strip_slash(base_url)}/eAIP_{_french_date_token(cycle)}"
         f"/FRANCE/AIRAC-{effective}/html/eAIP/{FRENCH_ENR44_HTML_FILENAME}"
     )
+
+
+def _effective_token(cycle: AiracCycle) -> str:
+    return f"{cycle.effective_date.day:02d} {_MONTH_TOKENS[cycle.effective_date.month - 1]} {cycle.year}"
+
+
+def _looks_like_cycle_heading(text: str) -> bool:
+    return "AIRAC" in text and "EFF " in text
+
+
+def _french_cycle_token(cycle: AiracCycle) -> str:
+    return f"{cycle.number:02d}/{cycle.year % 100:02d}"
+
+
+def _fetch_text(url: str, timeout: int = 30) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def _find_irish_eaip_enr44_url(
+    portal_html: str,
+    cycle: AiracCycle,
+    portal_url: str,
+) -> str:
+    """Return the target-cycle Irish ENR 4.4 HTML URL from the AirNav portal."""
+    soup = BeautifulSoup(portal_html, "html.parser")
+    needle = f"EFF {_effective_token(cycle)}"
+
+    for heading in soup.find_all(["h1", "h2", "h3", "h4"]):
+        heading_text = heading.get_text(" ", strip=True).upper()
+        if needle not in heading_text:
+            continue
+
+        for sibling in heading.next_siblings:
+            sibling_name = getattr(sibling, "name", None)
+            if sibling_name in {"h1", "h2", "h3", "h4"}:
+                sibling_text = sibling.get_text(" ", strip=True).upper()
+                if _looks_like_cycle_heading(sibling_text):
+                    break
+            if not hasattr(sibling, "find_all"):
+                continue
+            links = sibling.find_all("a", href=True)
+            if sibling_name == "a" and sibling.get("href"):
+                links = [sibling]
+            for link in links:
+                if "EAIP" in link.get_text(" ", strip=True).upper():
+                    index_url = urllib.parse.urljoin(portal_url, link["href"])
+                    return index_url.rsplit("/", 1)[0] + f"/eAIP/{IRISH_ENR44_HTML_FILENAME}"
+
+    raise Enr44HtmlLinkNotFound(
+        f"AirNav Ireland portal does not expose eAIP HTML for AIRAC {cycle.ident} "
+        f"({cycle.effective_date.isoformat()})."
+    )
+
+
+def _resolve_irish_enr44_url(
+    cycle: AiracCycle,
+    *,
+    base_url: str = IRISH_HTML_BASE_URL,
+    timeout: int = 30,
+) -> str:
+    portal_url = _irish_portal_url(base_url)
+    portal_html = _fetch_text(portal_url, timeout=timeout)
+    return _find_irish_eaip_enr44_url(portal_html, cycle, portal_url)
+
+
+def _find_french_product_enr44_url(
+    products_html: str,
+    cycle: AiracCycle,
+    *,
+    base_url: str = FRENCH_HTML_BASE_URL,
+) -> str:
+    """Return the target-cycle French ENR 4.4 HTML URL if the SIA page lists it."""
+    soup = BeautifulSoup(products_html, "html.parser")
+    cycle_token = _french_cycle_token(cycle)
+    effective_fr = cycle.effective_date.strftime("%d/%m/%Y")
+
+    for link in soup.find_all("a", href=True):
+        link_text = link.get_text(" ", strip=True).upper()
+        if "ZIP EAIP COMPLET" not in link_text or f"AIRAC {cycle_token}" not in link_text:
+            continue
+
+        block = link.find_parent(["li", "div", "article"]) or link.parent
+        block_text = block.get_text(" ", strip=True) if block else link_text
+        if effective_fr not in block_text:
+            continue
+
+        return _french_enr44_url(cycle, base_url=base_url)
+
+    raise Enr44HtmlLinkNotFound(
+        f"SIA France eAIP products page does not list AIRAC {cycle.ident} "
+        f"({cycle.effective_date.isoformat()})."
+    )
+
+
+def _resolve_french_enr44_url(
+    cycle: AiracCycle,
+    *,
+    base_url: str = FRENCH_HTML_BASE_URL,
+    products_url: str = FRENCH_EAIP_PRODUCTS_URL,
+    timeout: int = 30,
+) -> str:
+    products_html = _fetch_text(products_url, timeout=timeout)
+    return _find_french_product_enr44_url(products_html, cycle, base_url=base_url)
 
 
 def _download_html(url: str, dest: Path, timeout: int = 60) -> None:
@@ -107,11 +227,22 @@ def fetch_irish_enr44_html(
     dest_dir: Path,
     *,
     base_url: str = IRISH_HTML_BASE_URL,
+    page_timeout: int = 30,
     timeout: int = 60,
 ) -> Path | None:
     """Fetch EI-ENR-4.4-en-IE.html for *cycle* into *dest_dir*."""
     dest_dir.mkdir(parents=True, exist_ok=True)
-    url = _irish_enr44_url(cycle, base_url=base_url)
+    try:
+        url = _resolve_irish_enr44_url(cycle, base_url=base_url, timeout=page_timeout)
+    except Enr44HtmlLinkNotFound as exc:
+        logger.warning("%s", exc)
+        return None
+    except urllib.error.HTTPError as exc:
+        logger.warning("HTTP %d fetching Irish AIRAC portal - ENR 4.4 HTML skipped", exc.code)
+        return None
+    except urllib.error.URLError as exc:
+        logger.warning("Network error fetching Irish AIRAC portal - ENR 4.4 HTML skipped: %s", exc.reason)
+        return None
     dest = dest_dir / IRISH_ENR44_HTML_FILENAME
     logger.info("Fetching Irish ENR 4.4 HTML: %s", url)
     return _fetch_enr44_html(url, dest, "Irish", timeout=timeout)
@@ -122,11 +253,28 @@ def fetch_french_enr44_html(
     dest_dir: Path,
     *,
     base_url: str = FRENCH_HTML_BASE_URL,
+    products_url: str = FRENCH_EAIP_PRODUCTS_URL,
+    page_timeout: int = 30,
     timeout: int = 60,
 ) -> Path | None:
     """Fetch FR-ENR-4.4-fr-FR.html for *cycle* into *dest_dir*."""
     dest_dir.mkdir(parents=True, exist_ok=True)
-    url = _french_enr44_url(cycle, base_url=base_url)
+    try:
+        url = _resolve_french_enr44_url(
+            cycle,
+            base_url=base_url,
+            products_url=products_url,
+            timeout=page_timeout,
+        )
+    except Enr44HtmlLinkNotFound as exc:
+        logger.warning("%s", exc)
+        return None
+    except urllib.error.HTTPError as exc:
+        logger.warning("HTTP %d fetching SIA eAIP products page - ENR 4.4 HTML skipped", exc.code)
+        return None
+    except urllib.error.URLError as exc:
+        logger.warning("Network error fetching SIA eAIP products page - ENR 4.4 HTML skipped: %s", exc.reason)
+        return None
     dest = dest_dir / FRENCH_ENR44_HTML_FILENAME
     logger.info("Fetching French ENR 4.4 HTML: %s", url)
     return _fetch_enr44_html(url, dest, "French", timeout=timeout)

--- a/tests/test_foreign_enr44_html.py
+++ b/tests/test_foreign_enr44_html.py
@@ -11,6 +11,9 @@ from src.airac import cycle_for_date
 from src.sources.foreign_enr44_html import (
     FRENCH_ENR44_HTML_FILENAME,
     IRISH_ENR44_HTML_FILENAME,
+    Enr44HtmlLinkNotFound,
+    _find_french_product_enr44_url,
+    _find_irish_eaip_enr44_url,
     _french_enr44_url,
     _irish_enr44_url,
     fetch_french_enr44_html,
@@ -18,6 +21,7 @@ from src.sources.foreign_enr44_html import (
 )
 
 CYCLE_2603 = cycle_for_date(date(2026, 3, 19))
+CYCLE_2606 = cycle_for_date(date(2026, 6, 11))
 
 
 def test_irish_enr44_url_uses_cycle_effective_date():
@@ -37,11 +41,109 @@ def test_french_enr44_url_uses_sia_dvd_cycle_path():
     )
 
 
+def test_irish_portal_discovery_uses_matching_effective_date():
+    html = """
+    <h2>AIRAC AMDT 002/2026 ; EFF 19 FEB 2026</h2>
+    <h3><a href="2026-02-19-AIRAC/html/index.html">eAIP</a></h3>
+    <h2>FUTURE AIRAC AMDT 003/2026 ; EFF 19 MAR 2026</h2>
+    <h3><a href="2026-03-19-AIRAC/html/index.html">eAIP</a></h3>
+    """
+
+    assert _find_irish_eaip_enr44_url(html, CYCLE_2603, "https://www.airnav.ie/AIRAC/index.html") == (
+        "https://www.airnav.ie/AIRAC/2026-03-19-AIRAC/html/eAIP/EI-ENR-4.4-en-IE.html"
+    )
+
+
+def test_irish_portal_discovery_returns_unavailable_for_tba_future_cycle():
+    html = """
+    <h2>AIRAC AMDT 005/2026 ; EFF 14 MAY 2026</h2>
+    <h3><a href="2026-05-14-AIRAC/html/index.html">eAIP</a></h3>
+    <h2>FUTURE AIRAC AMDT 006/2026 ; EFF 11 JUN 2026</h2>
+    <h3>TBA</h3>
+    """
+
+    try:
+        _find_irish_eaip_enr44_url(html, CYCLE_2606, "https://www.airnav.ie/AIRAC/index.html")
+    except Enr44HtmlLinkNotFound:
+        pass
+    else:
+        raise AssertionError("future TBA cycle should not resolve to the current eAIP")
+
+
+def test_irish_portal_discovery_stops_at_next_h3_cycle_heading():
+    html = """
+    <h3>FUTURE AIRAC AMDT 006/2026 ; EFF 11 JUN 2026</h3>
+    <p>TBA</p>
+    <h3>AIRAC AMDT 007/2026 ; EFF 09 JUL 2026</h3>
+    <h4><a href="2026-07-09-AIRAC/html/index.html">eAIP</a></h4>
+    """
+
+    try:
+        _find_irish_eaip_enr44_url(html, CYCLE_2606, "https://www.airnav.ie/AIRAC/index.html")
+    except Enr44HtmlLinkNotFound:
+        pass
+    else:
+        raise AssertionError("target TBA h3 cycle should not scan into the next h3 cycle block")
+
+
+def test_french_products_discovery_requires_matching_airac_product():
+    html = """
+    <ol>
+      <li>
+        <a href="/zip-eaip-complet-airac-02-26.html">ZIP eAIP Complet AIRAC 02/26</a>
+        En vigueur du 19/02/2026 au 18/03/2026 inclus
+      </li>
+      <li>
+        <a href="/zip-eaip-complet-airac-03-26.html">ZIP eAIP Complet AIRAC 03/26</a>
+        En vigueur du 19/03/2026 au 15/04/2026 inclus
+      </li>
+    </ol>
+    """
+
+    assert _find_french_product_enr44_url(
+        html,
+        CYCLE_2603,
+        base_url="https://www.sia.aviation-civile.gouv.fr/media/dvd",
+    ) == (
+        "https://www.sia.aviation-civile.gouv.fr/media/dvd/eAIP_19_MAR_2026"
+        "/FRANCE/AIRAC-2026-03-19/html/eAIP/FR-ENR-4.4-fr-FR.html"
+    )
+
+
+def test_french_products_discovery_does_not_use_current_cycle_for_unlisted_future_cycle():
+    html = """
+    <ol>
+      <li>
+        <a href="/zip-eaip-complet-airac-05-26.html">ZIP eAIP Complet AIRAC 05/26</a>
+        En vigueur du 14/05/2026 au 10/06/2026 inclus
+      </li>
+    </ol>
+    """
+
+    try:
+        _find_french_product_enr44_url(html, CYCLE_2606)
+    except Enr44HtmlLinkNotFound:
+        pass
+    else:
+        raise AssertionError("unlisted future cycle should not resolve to the current SIA product")
+
+
+def test_french_date_token_pads_first_day_of_month():
+    cycle = cycle_for_date(date(2026, 10, 1))
+    assert "eAIP_01_OCT_2026" in _french_enr44_url(cycle)
+
+
 def test_fetch_irish_enr44_html_writes_expected_file(tmp_path):
     def fake_download(url: str, dest: Path, timeout: int = 60) -> None:
         dest.write_text(f"<html>{url}</html>", encoding="utf-8")
 
-    with patch("src.sources.foreign_enr44_html._download_html", side_effect=fake_download):
+    with (
+        patch(
+            "src.sources.foreign_enr44_html._resolve_irish_enr44_url",
+            return_value="https://irish.example/AIRAC/2026-03-19-AIRAC/html/eAIP/EI-ENR-4.4-en-IE.html",
+        ),
+        patch("src.sources.foreign_enr44_html._download_html", side_effect=fake_download),
+    ):
         result = fetch_irish_enr44_html(
             CYCLE_2603,
             tmp_path,
@@ -56,7 +158,16 @@ def test_fetch_french_enr44_html_writes_expected_file(tmp_path):
     def fake_download(url: str, dest: Path, timeout: int = 60) -> None:
         dest.write_text(f"<html>{url}</html>", encoding="utf-8")
 
-    with patch("src.sources.foreign_enr44_html._download_html", side_effect=fake_download):
+    with (
+        patch(
+            "src.sources.foreign_enr44_html._resolve_french_enr44_url",
+            return_value=(
+                "https://french.example/media/dvd/eAIP_19_MAR_2026"
+                "/FRANCE/AIRAC-2026-03-19/html/eAIP/FR-ENR-4.4-fr-FR.html"
+            ),
+        ),
+        patch("src.sources.foreign_enr44_html._download_html", side_effect=fake_download),
+    ):
         result = fetch_french_enr44_html(
             CYCLE_2603,
             tmp_path,
@@ -70,7 +181,7 @@ def test_fetch_french_enr44_html_writes_expected_file(tmp_path):
 def test_fetch_irish_enr44_html_returns_none_on_http_error(tmp_path):
     err = urllib.error.HTTPError("https://example.test", 404, "not found", hdrs=None, fp=None)
 
-    with patch("src.sources.foreign_enr44_html._download_html", side_effect=err):
+    with patch("src.sources.foreign_enr44_html._resolve_irish_enr44_url", side_effect=err):
         result = fetch_irish_enr44_html(CYCLE_2603, tmp_path)
 
     assert result is None
@@ -80,7 +191,7 @@ def test_fetch_irish_enr44_html_returns_none_on_http_error(tmp_path):
 def test_fetch_french_enr44_html_returns_none_on_url_error(tmp_path):
     err = urllib.error.URLError("connection refused")
 
-    with patch("src.sources.foreign_enr44_html._download_html", side_effect=err):
+    with patch("src.sources.foreign_enr44_html._resolve_french_enr44_url", side_effect=err):
         result = fetch_french_enr44_html(CYCLE_2603, tmp_path)
 
     assert result is None
@@ -88,7 +199,10 @@ def test_fetch_french_enr44_html_returns_none_on_url_error(tmp_path):
 
 
 def test_fetch_french_enr44_html_returns_none_on_io_error(tmp_path):
-    with patch("src.sources.foreign_enr44_html._download_html", side_effect=OSError("disk full")):
+    with (
+        patch("src.sources.foreign_enr44_html._resolve_french_enr44_url", return_value="https://example.test/fr.html"),
+        patch("src.sources.foreign_enr44_html._download_html", side_effect=OSError("disk full")),
+    ):
         result = fetch_french_enr44_html(CYCLE_2603, tmp_path)
 
     assert result is None


### PR DESCRIPTION
Closes #24.\n\n## Summary\n- resolve Irish ENR 4.4 HTML by reading the AirNav AIRAC portal and following the eAIP pointer for the target effective date\n- resolve French ENR 4.4 HTML only after the SIA eAIP product listing exposes the matching AIRAC product and validity start date\n- keep missing/unpublished future cycles non-fatal rather than falling back to current-cycle data\n- update fetcher docs/config comments to describe pointer discovery instead of deterministic direct fetches\n\n## Tests\n- python -m pytest tests/test_foreign_enr44_html.py tests/test_cli.py tests/test_config.py\n- python -m pytest\n\nFull result: 269 passed.