### PR TITLE
fix: trim trailing empty columns in SRD CSV export

### DIFF
--- a/src/processing/excel_to_csv.py
+++ b/src/processing/excel_to_csv.py
@@ -91,15 +91,40 @@ def _find_whats_new_date(ws) -> date | None:
     return None
 
 
+def _last_populated_column(ws) -> int:
+    """Return the count of columns up to and including the last one that
+    holds a non-empty value anywhere in *ws*.
+
+    Some workbooks report an inflated ``ws.dimensions``/``max_column`` far
+    beyond the real data extent (e.g. stray formatting applied to a large
+    range). Trusting that bound when exporting to CSV pads every row with
+    thousands of empty trailing fields, bloating file size by orders of
+    magnitude with no content gained. Scanning for the true rightmost
+    non-empty cell keeps the export trimmed to the actual data.
+    """
+    max_col = 0
+    for row in ws.iter_rows(values_only=True):
+        for idx in range(len(row) - 1, max_col - 1, -1):
+            value = row[idx]
+            if value is not None and str(value).strip() != "":
+                max_col = idx + 1
+                break
+    return max_col
+
+
 def _sheet_to_csv(ws, dest_path: Path) -> Path:
     """Write all rows from *ws* to a CSV file at *dest_path*.
 
     None values are written as empty strings so the CSV remains well-formed.
+    Rows are trimmed to the last column containing any value anywhere in the
+    sheet, discarding trailing empty columns (see `_last_populated_column`).
     """
+    max_col = _last_populated_column(ws)
     with dest_path.open("w", newline="", encoding="utf-8") as fh:
         writer = csv.writer(fh)
         for row in ws.iter_rows(values_only=True):
-            writer.writerow(["" if v is None else v for v in row])
+            trimmed = row[:max_col] if max_col else row
+            writer.writerow(["" if v is None else v for v in trimmed])
     return dest_path
 
 

--- a/tests/test_excel_to_csv.py
+++ b/tests/test_excel_to_csv.py
@@ -296,3 +296,21 @@ class TestConvertSrdExcel:
         result = convert_srd_excel(path, out, CYCLE_2602)
         for p in result.values():
             assert p.parent == out
+
+    def test_trailing_empty_columns_trimmed(self, tmp_path):
+        # Regression: inflated ws.dimensions (e.g. stray formatting far
+        # beyond real data) must not pad the CSV with empty trailing fields.
+        out = tmp_path / "out"
+        path = _make_workbook(tmp_path)
+        wb = openpyxl.load_workbook(path)
+        ws = wb[_NOTES_SHEET]
+        ws.cell(row=1, column=500, value=None)
+        ws.cell(row=1, column=500).fill = openpyxl.styles.PatternFill(
+            start_color="FFFF00", end_color="FFFF00", fill_type="solid"
+        )
+        wb.save(path)
+
+        result = convert_srd_excel(path, out, CYCLE_2602)
+        rows = list(csv.reader(result[_NOTES_SHEET].open(encoding="utf-8")))
+        assert len(rows[0]) == len(NOTES_DATA[0])
+        assert len(rows[1]) == len(NOTES_DATA[0])


### PR DESCRIPTION
## Summary
- `_sheet_to_csv` trusted `ws.max_column`/`ws.dimensions` when exporting, but some worksheets report an inflated used-range far beyond the real data extent (e.g. stray formatting on a wide range). This pads every exported row with thousands of empty trailing CSV fields.
- Added `_last_populated_column` to scan for the true rightmost non-empty cell across the whole sheet, and trim each exported row to that width.

## Context
Found while investigating a 32MB `Notes.csv` for AIRAC 2607 vs ~48KB in prior cycles. This fix is a real, general hardening against inflated-dimensions bloat, but does **not** fully resolve the 2607 case -- a handful of rows in that specific source workbook contain genuine (non-empty) duplicated content out to column XFD, which is a source-data issue rather than an inflated-dimensions issue. That is being handled separately.

## Test plan
- [x] `python -m pytest tests/test_excel_to_csv.py -v` -- 31/31 passed, including new regression test `test_trailing_empty_columns_trimmed`
- [x] `python -m pytest` (full suite) -- 289/289 passed